### PR TITLE
Add missing require

### DIFF
--- a/local/gnome-shell-mode/gnome-shell-mode.el
+++ b/local/gnome-shell-mode/gnome-shell-mode.el
@@ -40,6 +40,7 @@
 
 ;;; Code:
 
+(require 'dbus)
 
 (defconst gnome-shell--helper-path
   (file-name-directory (or load-file-name buffer-file-name)))


### PR DESCRIPTION
`dbus-call-method' is not autoloaded.