### PR TITLE
fix recursive link creation by derefencing extension symlink (since i…

### DIFF
--- a/local/gnome-shell-mode/session.sh
+++ b/local/gnome-shell-mode/session.sh
@@ -19,7 +19,7 @@ mkdir -p $CACHE
 export XDG_CONFIG_HOME=${CACHE}/config
 export XDG_DATA_HOME=${CACHE}/local
 mkdir -p $XDG_DATA_HOME/gnome-shell/extensions
-ln -fs $ROOT $XDG_DATA_HOME/gnome-shell/extensions/${UUID}
+ln -fsn $ROOT $XDG_DATA_HOME/gnome-shell/extensions/${UUID}
 export XDG_CACHE_HOME=${CACHE}/cache
 
 DISPLAY=$NEW_DISPLAY


### PR DESCRIPTION
…t's a directory)

Without the `-n` flag to `ln` if a symlink to directory already exists another one is created inside of existing symlinked directory.
Which means the symlink is never updates and it polutes the symlinked repository to itself
```
$ tree /home/user/.cache/paperwm@hedning:matrix.org/local/gnome-shell/extensions/
/home/user/.cache/paperwm@hedning:matrix.org/local/gnome-shell/extensions/
└── paperwm@hedning:matrix.org -> /home/user/paperwm

$ tree /home/user/.cache/paperwm@hedning:matrix.org/local/gnome-shell/extensions/paperwm@hedning:matrix.org
/home/user/.cache/paperwm@hedning:matrix.org/local/gnome-shell/extensions/paperwm@hedning:matrix.org
├── <various files and folders>
├── mr.sequential-workspaces -> /home/user/paperwm
└── <various files and folders>
```