### PR TITLE
Add support for gnome 43

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,28 @@ See `gnome-shell-mode-pkg.el` and `company-gnome-shell.el` for list of dependenc
 
 NB: The rest of the readme describe the keybindings defined by the spacemacs layer. Some vanilla emacs bindings are also defined by default. See the bottom of `gnome-shell-mode.el`. 
 
+## Initial Setup
+
+NOTE: For older gnome versions this is not needed. But it is required for at least Gnome 43.
+
+This is only required the very first time you use the gnome-shell-mode, because we install a gnome extensions (called gnome-shell-mode) that is required to provide the functionality of gnome-shell-mode.
+
+The first time you use gnome-shell-mode you need to enable `unsafe_mode` in the gnome-shell. You can do this by executing the following in LookingGlass (i.e. hit <kbd>Alt+F2</kbd>, type `lg` and <kbd>Enter</kbd>):
+
+``` javascript
+global.context.unsafe_mode = true
+```
+
+Then start Emacs and use one of the functions/keybindings of gnome-shell-mode.
+
+Afterwards that you can disable `unsafe_mode` again and gnome-shell-mode should continue to work.
+
+If you skip this step you will see an error similar to the following in Emacs and none of the functionality of gnome-shell-mode will work:
+
+```
+dbus-call-method: D-Bus error: "org.freedesktop.DBus.Error.UnknownMethod", "Object does not exist at path “/gnome/shell/mode”"
+```
+
 ## Usage
 
 Make sure you're in gnome-shell-mode (eg. by using <kbd>M-x gnome-shell-mode</kbd>). All the actions will then be under the major-mode leader key (<kbd>M-m</kbd> or <kbd>,</kbd>).

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Then add this to `init.el`:
 
     (require 'gnome-shell-mode)
     (require 'company-gnome-shell)
-    
+
     ;; Most staight forward but might mess up company in other modes?
     (eval-after-load "company"
      (add-to-list 'company-backends 'company-gnome-shell))
@@ -120,9 +120,9 @@ NB: The rest of the readme describe the keybindings defined by the spacemacs lay
 
 NOTE: For older gnome versions this is not needed. But it is required for at least Gnome 43.
 
-This is only required the very first time you use the gnome-shell-mode, because we install a gnome extensions (called gnome-shell-mode) that is required to provide the functionality of gnome-shell-mode.
+This is required because we install a gnome extensions (called gnome-shell-mode) that is required to provide the functionality of gnome-shell-mode.
 
-The first time you use gnome-shell-mode you need to enable `unsafe_mode` in the gnome-shell. You can do this by executing the following in LookingGlass (i.e. hit <kbd>Alt+F2</kbd>, type `lg` and <kbd>Enter</kbd>):
+You need to enable `unsafe_mode` in the gnome-shell. You can do this by executing the following in LookingGlass (i.e. hit <kbd>Alt+F2</kbd>, type `lg` and <kbd>Enter</kbd>):
 
 ``` javascript
 global.context.unsafe_mode = true
@@ -140,7 +140,7 @@ dbus-call-method: D-Bus error: "org.freedesktop.DBus.Error.UnknownMethod", "Obje
 
 ## Usage
 
-Make sure you're in gnome-shell-mode (eg. by using <kbd>M-x gnome-shell-mode</kbd>). All the actions will then be under the major-mode leader key (<kbd>M-m</kbd> or <kbd>,</kbd>).
+Make sure you're in gnome-shell-mode (e.g. by using <kbd>M-x gnome-shell-mode</kbd>). All the actions will then be under the major-mode leader key (<kbd>M-m</kbd> or <kbd>,</kbd>).
 
 For instance <kbd>,sf</kbd> will evaluate the surrounding function and the evaluated region will pulse green or red depending on the success of the evaluation. If an error occurred, the position reported by gjs will be marked as a flycheck error.
 

--- a/local/gnome-shell-mode/gnome-shell-mode@hedning:matrix.org/emacs.js
+++ b/local/gnome-shell-mode/gnome-shell-mode@hedning:matrix.org/emacs.js
@@ -610,7 +610,7 @@ function findExtension(projectRoot) {
     let metadataFile = `${projectRoot}/metadata.json`;
     if (GLib.file_test(metadataFile, GLib.FileTest.IS_REGULAR)) {
         const [success, metadata] = GLib.file_get_contents(metadataFile);
-        let uuid = JSON.parse(metadata.toString()).uuid;
+        let uuid = JSON.parse(new TextDecoder().decode(metadata)).uuid;
         if (uuid === undefined)
             return false;
         if (imports.misc.extensionUtils.extensions) {

--- a/local/gnome-shell-mode/gnome-shell-mode@hedning:matrix.org/metadata.json
+++ b/local/gnome-shell-mode/gnome-shell-mode@hedning:matrix.org/metadata.json
@@ -3,5 +3,5 @@
   "name": "gnome-shell-mode",
   "description": "Javascript server for emacs",
   "url": "https://github.com/paperwm/gnome-shell-mode",
-  "shell-version": [ "3.22", "3.24", "3.26" ]
+  "shell-version": [ "3.22", "3.24", "3.26", "40", "41", "42", "43" ]
 }


### PR DESCRIPTION
This adds support for gnome version 43 and also added some explanation of how to use this repo with recent gnome versions (i.e. enable `unsafe_mode`).

Note that I added versions 40-43 in the metadata.json but I only tested on gnome version 43. I can remove the other versions if you are more comfortable with that.

I also fixed a deprecated function call that will become an error in the future.

Other than that this repo seems to work perfectly for gnome 43.